### PR TITLE
ADDING Length of stay function + flag

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -776,13 +776,7 @@ public class FhirR4 {
       Extension lengthOfStay = new Extension(url);
       lengthOfStay.setValue(length_of_stay);
       encounterResource.addExtension(lengthOfStay);
-    } else if (longStart == null) {
-      System.err.println("encounter.start field is NULL");
-    } else if (longStop == null) {
-      System.err.println("encounter.stop field is NULL");
-    } else if (status != EncounterStatus.FINISHED) {
-      System.err.println("encounter.status is not FINISHED");
-    }
+    } 
 
     if (encounter.reason != null) {
       encounterResource.addReasonCode().addCoding().setCode(encounter.reason.code)

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -1,5 +1,8 @@
 # Starting with a properties file because it requires no additional dependencies
 
+# Add verily extensions flag
+exporter.fhir.add_verily_extensions = true
+
 exporter.baseDirectory = ./output/
 exporter.use_uuid_filenames = false
 exporter.subfolders_by_id_substring = false


### PR DESCRIPTION
Adding `length of stay` funcitonality at `FhirR4.java` as a method. 
Adding `exporter.fhir.add_verily_extensions` flag. When true -> extension methods get called at `FhirR4.java`

At terminal, run:
`./run_synthea --exporter.fhir.add_verily_extensions true` 
To use length of stay functionality

At terminal, run:
`./run_synthea --exporter.fhir.add_verily_extensions false` 
To turn off length of stay functionality